### PR TITLE
feat: snap scrolling

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -52,6 +52,11 @@ const { title, youtubeUrl, slug } = Astro.props;
     column-gap: 1.5rem;
     row-gap: 1rem;
     background-color: hsl(var(--color-hs), 99%);
+    scroll-snap-align: start;
+    scroll-margin-top: 0.9rem;
+    
+    /* Can remove this if you want to glide through the vids */
+    scroll-snap-stop: always;
   }
 
   .ctas {
@@ -69,6 +74,8 @@ const { title, youtubeUrl, slug } = Astro.props;
       grid-template-areas:
         "video body"
         "video ctas";
+      scroll-snap-align: center;
+      scroll-margin-top: unset;
     }
 
     .ctas {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -120,6 +120,18 @@ const videos = await getVideosWithThumbnail(query ?? undefined);
 </script>
 
 <style>
+  html {
+    scroll-snap-type: y mandatory;
+  }
+
+  header {
+    scroll-snap-align: start;
+  }
+
+  footer {
+    scroll-snap-align: end;
+  }
+
   .heading {
     display: grid;
     margin-block: 1rem;


### PR DESCRIPTION
This adds snap scrolling to the wtw.dev webpage.

Why?
Uniformity and confirmation to UX with other short form content websites will allow for a better experience for the users.

Changes:
1. Adds snap scrolling to html element
2. Header and Article will snap to top on mobile views
3. Article will snap to center on larger views
4. Footer snaps to bottom (default)

File changes:
src/components/Card.astro
src/index.astro